### PR TITLE
flake: add checks for CI package builds

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -20,5 +20,7 @@
       packages = forAllSystems (system: import ./. { pkgs = import nixpkgs { inherit system; }; });
 
       overlays.default = import ./overlays;
+
+      checks = self.packages;
     };
 }


### PR DESCRIPTION
This enables automated build verification in CI by exposing all packages through the checks output, which was previously missing.